### PR TITLE
Add Same Background Blur Effects for Context Menus

### DIFF
--- a/theme/shared.css
+++ b/theme/shared.css
@@ -5,3 +5,8 @@
 .backgroundglass_DrawBackground_2NQoF {
     background: rgba(7, 9, 13, var(--betterBlur-opacity)) !important;
 }
+
+.gamepadui_GamepadDialogOverlay_34Euf .ModalOverlayBackground {
+    backdrop-filter: blur(var(--betterBlur-strength)) !important;
+    background: rgba(7, 9, 13, var(--betterBlur-opacity)) !important;
+}


### PR DESCRIPTION
When opening context menus, the background is blurred, with a grey filter. The Better Blur slider settings will now modify the background for context menu popups, as well as QAM/Steam menu.